### PR TITLE
fix(coerce): improves coercion of nested arrays

### DIFF
--- a/src/lib/coerce.test.ts
+++ b/src/lib/coerce.test.ts
@@ -27,12 +27,63 @@ describe("coerce", () => {
   it("coerces arrays of values", () => {
     expect(
       coerce({
-        foo: ["1", "1.5", "hello", "null", "true", false, 1]
+        foo: ["1", "1.5", "hello", "null", "true", false, 1],
       })
     ).toEqual({ foo: [1, 1.5, "hello", null, true, false, 1] });
   });
 
   it("coerces arrays with a single value", () => {
     expect(coerce({ foo: ["1"] })).toEqual({ foo: [1] });
+  });
+
+  it("coerces nested arrays", () => {
+    expect(
+      coerce(
+        {
+          foo: [
+            ["1", "2", "3"],
+            ["4", "5", "6"],
+            ["a", "b", "c"],
+          ],
+        },
+        {
+          // Ignores hints
+          foo: [
+            ["a", "b", "c"],
+            [1, 2],
+          ],
+        }
+      )
+    ).toEqual({
+      foo: [
+        [1, 2, 3],
+        [4, 5, 6],
+        ["a", "b", "c"],
+      ],
+    });
+  });
+
+  it("allows strict arrays to be enforced", () => {
+    expect(
+      coerce(
+        {
+          foo: [
+            ["1", "2", "3"],
+            ["4", "5", "6"],
+            ["a", "b", "c"],
+          ],
+        },
+        {
+          // Ignores hints
+          foo: [
+            ["a", "b", "c"],
+            [1, 2],
+          ],
+        },
+        { strictArrays: true }
+      )
+    ).toEqual({
+      foo: [["1", "2", "3"], [4, 5, null], null],
+    });
   });
 });

--- a/src/lib/encode.test.ts
+++ b/src/lib/encode.test.ts
@@ -1,5 +1,6 @@
 import { encode } from "./encode";
 import { params } from "./params";
+import { parse } from "./parse";
 
 describe("encode", () => {
   it("produces a new querystring given a new set of params", () => {
@@ -18,5 +19,17 @@ describe("encode", () => {
     );
 
     expect(params({}, querystring)).toEqual(options);
+  });
+
+  it("encodes nested arrays correctly", () => {
+    const options = {
+      ops: [
+        ["a", "b", "c"],
+        ["d", "e", "f"],
+      ],
+    };
+
+    const querystring = encode(options);
+    expect(parse(querystring)).toEqual(options);
   });
 });


### PR DESCRIPTION
Will surface the `strictArrays` option into configure. But I suspect the use-case for that will be very rare (basically if you want arrays of numeric strings). Sort of highlights the issue with using value-based hints for typing instead of a structured input.